### PR TITLE
OT119-40: Implemented creation of endpoint "/activities" to create activitties through an HTTP POST method

### DIFF
--- a/etc/postman/OT-119.postman_collection.json
+++ b/etc/postman/OT-119.postman_collection.json
@@ -171,7 +171,39 @@
 				}
 			},
 			"response": []
-		}
+		},
+        {
+			"name": "Activity",
+			"item": [
+				{
+					"name": "POST /activities: create activites",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"Actividad 1\",\n    \"content\": \"Contenido de actividad 1\",\n    \"image\": \"http://somosmas/actividad1.png\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "localhost:8080/activities",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"activities"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+        }
 	],
 	"event": [
 		{

--- a/src/main/java/com/alkemy/ong/common/DtoUtils.java
+++ b/src/main/java/com/alkemy/ong/common/DtoUtils.java
@@ -33,7 +33,6 @@ public class DtoUtils {
     activity.setName(activityDetailsRequest.getName());
     activity.setContent(activityDetailsRequest.getContent());
     activity.setImage(activityDetailsRequest.getImage());
-    activity.setTimestamps(activityDetailsRequest.getTimestamp());
     return activity;
   }
 

--- a/src/main/java/com/alkemy/ong/common/DtoUtils.java
+++ b/src/main/java/com/alkemy/ong/common/DtoUtils.java
@@ -1,7 +1,9 @@
 package com.alkemy.ong.common;
 
+import com.alkemy.ong.model.entity.Activity;
 import com.alkemy.ong.model.entity.Category;
 import com.alkemy.ong.model.entity.User;
+import com.alkemy.ong.model.request.ActivityDetailsRequest;
 import com.alkemy.ong.model.request.CategoryDetailsRequest;
 import com.alkemy.ong.model.request.UserDetailsRequest;
 
@@ -17,12 +19,22 @@ public class DtoUtils {
     user.setEmail(userDetailsRequest.getEmail());
     return user;
   }
-  public static Category convertTo(CategoryDetailsRequest categoryDetailsRequest){
+
+  public static Category convertTo(CategoryDetailsRequest categoryDetailsRequest) {
     Category category = new Category();
     category.setName(categoryDetailsRequest.getName());
     category.setDescription(categoryDetailsRequest.getDescription());
     category.setImage(categoryDetailsRequest.getImage());
     return category;
+  }
+
+  public static Activity convertTo(ActivityDetailsRequest activityDetailsRequest) {
+    Activity activity = new Activity();
+    activity.setName(activityDetailsRequest.getName());
+    activity.setContent(activityDetailsRequest.getContent());
+    activity.setImage(activityDetailsRequest.getImage());
+    activity.setTimestamps(activityDetailsRequest.getTimestamp());
+    return activity;
   }
 
 }

--- a/src/main/java/com/alkemy/ong/common/EntityUtils.java
+++ b/src/main/java/com/alkemy/ong/common/EntityUtils.java
@@ -1,11 +1,13 @@
 package com.alkemy.ong.common;
 
+import com.alkemy.ong.model.entity.Activity;
 import com.alkemy.ong.model.entity.Category;
 import com.alkemy.ong.model.entity.News;
 import com.alkemy.ong.model.entity.Organization;
 import com.alkemy.ong.model.entity.Role;
 import com.alkemy.ong.model.entity.Slide;
 import com.alkemy.ong.model.entity.User;
+import com.alkemy.ong.model.response.ActivityDetailsResponse;
 import com.alkemy.ong.model.response.CategoryDetailsResponse;
 import com.alkemy.ong.model.response.ListUserResponse;
 import com.alkemy.ong.model.response.NewsDetailsResponse;
@@ -78,6 +80,14 @@ public class EntityUtils {
       roleResponses.add(convertTo(role));
     }
     return roleResponses;
+  }
+
+  public static ActivityDetailsResponse convertTo(Activity activity) {
+    ActivityDetailsResponse activityDetailsResponse = new ActivityDetailsResponse();
+    activityDetailsResponse.setName(activity.getName());
+    activityDetailsResponse.setContent(activity.getContent());
+    activityDetailsResponse.setImage(activity.getImage());
+    return activityDetailsResponse;
   }
 
   public static ListUserResponse convertToListUserResponse(List<User> users) {

--- a/src/main/java/com/alkemy/ong/common/EntityUtils.java
+++ b/src/main/java/com/alkemy/ong/common/EntityUtils.java
@@ -87,6 +87,7 @@ public class EntityUtils {
     activityDetailsResponse.setName(activity.getName());
     activityDetailsResponse.setContent(activity.getContent());
     activityDetailsResponse.setImage(activity.getImage());
+    activityDetailsResponse.setTimestamp(activity.getTimestamps());
     return activityDetailsResponse;
   }
 

--- a/src/main/java/com/alkemy/ong/config/security/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/config/security/SecurityConfig.java
@@ -85,6 +85,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .hasAnyRole(ApplicationRole.ADMIN.getName())
         .antMatchers(HttpMethod.POST, "/categories")
         .hasAnyRole(ApplicationRole.ADMIN.getName())
+        .antMatchers(HttpMethod.POST, "/activities")
+        .hasAnyRole(ApplicationRole.ADMIN.getName())
         .anyRequest()
         .authenticated()
         .and()

--- a/src/main/java/com/alkemy/ong/controller/ActivityController.java
+++ b/src/main/java/com/alkemy/ong/controller/ActivityController.java
@@ -1,0 +1,27 @@
+package com.alkemy.ong.controller;
+
+import com.alkemy.ong.model.request.ActivityDetailsRequest;
+import com.alkemy.ong.model.response.ActivityDetailsResponse;
+import com.alkemy.ong.service.ActivityServiceImpl;
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ActivityController {
+
+  @Autowired
+  private ActivityServiceImpl activityService;
+
+  @PostMapping("/activities")
+  public ResponseEntity<ActivityDetailsResponse> createActivity(@Valid @RequestBody
+      ActivityDetailsRequest activityDetailsRequest) {
+    ActivityDetailsResponse activityDetailsResponse = activityService.create(
+        activityDetailsRequest);
+    return ResponseEntity.status(HttpStatus.CREATED).body(activityDetailsResponse);
+  }
+}

--- a/src/main/java/com/alkemy/ong/controller/ActivityController.java
+++ b/src/main/java/com/alkemy/ong/controller/ActivityController.java
@@ -2,7 +2,7 @@ package com.alkemy.ong.controller;
 
 import com.alkemy.ong.model.request.ActivityDetailsRequest;
 import com.alkemy.ong.model.response.ActivityDetailsResponse;
-import com.alkemy.ong.service.ActivityServiceImpl;
+import com.alkemy.ong.service.abstraction.ICreateActivityService;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -15,12 +15,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class ActivityController {
 
   @Autowired
-  private ActivityServiceImpl activityService;
+  private ICreateActivityService createActivityService;
 
   @PostMapping("/activities")
   public ResponseEntity<ActivityDetailsResponse> createActivity(@Valid @RequestBody
       ActivityDetailsRequest activityDetailsRequest) {
-    ActivityDetailsResponse activityDetailsResponse = activityService.create(
+    ActivityDetailsResponse activityDetailsResponse = createActivityService.create(
         activityDetailsRequest);
     return ResponseEntity.status(HttpStatus.CREATED).body(activityDetailsResponse);
   }

--- a/src/main/java/com/alkemy/ong/controller/ActivityController.java
+++ b/src/main/java/com/alkemy/ong/controller/ActivityController.java
@@ -18,7 +18,7 @@ public class ActivityController {
   private ICreateActivityService createActivityService;
 
   @PostMapping("/activities")
-  public ResponseEntity<ActivityDetailsResponse> createActivity(@Valid @RequestBody
+  public ResponseEntity<ActivityDetailsResponse> create(@Valid @RequestBody
       ActivityDetailsRequest activityDetailsRequest) {
     ActivityDetailsResponse activityDetailsResponse = createActivityService.create(
         activityDetailsRequest);

--- a/src/main/java/com/alkemy/ong/model/request/ActivityDetailsRequest.java
+++ b/src/main/java/com/alkemy/ong/model/request/ActivityDetailsRequest.java
@@ -19,5 +19,4 @@ public class ActivityDetailsRequest {
   private String content;
   @NotBlank(message = "Image cannot be empty.")
   private String image;
-  private Timestamp timestamp;
 }

--- a/src/main/java/com/alkemy/ong/model/request/ActivityDetailsRequest.java
+++ b/src/main/java/com/alkemy/ong/model/request/ActivityDetailsRequest.java
@@ -1,6 +1,5 @@
 package com.alkemy.ong.model.request;
 
-import java.sql.Timestamp;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/alkemy/ong/model/request/ActivityDetailsRequest.java
+++ b/src/main/java/com/alkemy/ong/model/request/ActivityDetailsRequest.java
@@ -1,0 +1,23 @@
+package com.alkemy.ong.model.request;
+
+import java.sql.Timestamp;
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ActivityDetailsRequest {
+
+  @NotBlank(message = "A name is required in order to create this activity.")
+  private String name;
+  @NotBlank(message = "Content must be specified for this activity.")
+  private String content;
+  @NotBlank(message = "Image cannot be empty.")
+  private String image;
+  private Timestamp timestamp;
+}

--- a/src/main/java/com/alkemy/ong/model/response/ActivityDetailsResponse.java
+++ b/src/main/java/com/alkemy/ong/model/response/ActivityDetailsResponse.java
@@ -1,7 +1,6 @@
 package com.alkemy.ong.model.response;
 
 import java.sql.Timestamp;
-import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/alkemy/ong/model/response/ActivityDetailsResponse.java
+++ b/src/main/java/com/alkemy/ong/model/response/ActivityDetailsResponse.java
@@ -1,0 +1,19 @@
+package com.alkemy.ong.model.response;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ActivityDetailsResponse {
+
+  private String name;
+  private String content;
+  private String image;
+
+}

--- a/src/main/java/com/alkemy/ong/model/response/ActivityDetailsResponse.java
+++ b/src/main/java/com/alkemy/ong/model/response/ActivityDetailsResponse.java
@@ -1,5 +1,6 @@
 package com.alkemy.ong.model.response;
 
+import java.sql.Timestamp;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,5 +16,6 @@ public class ActivityDetailsResponse {
   private String name;
   private String content;
   private String image;
+  private Timestamp timestamp;
 
 }

--- a/src/main/java/com/alkemy/ong/service/ActivityServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/ActivityServiceImpl.java
@@ -14,11 +14,12 @@ import org.springframework.stereotype.Service;
 public class ActivityServiceImpl implements ICreateActivityService {
 
   @Autowired
-  IActivityRepository activityRepository;
+  private IActivityRepository activityRepository;
 
   @Override
   public ActivityDetailsResponse create(ActivityDetailsRequest activityRequest) {
     Activity activity = DtoUtils.convertTo(activityRequest);
     return EntityUtils.convertTo(activityRepository.save(activity));
   }
+
 }

--- a/src/main/java/com/alkemy/ong/service/ActivityServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/ActivityServiceImpl.java
@@ -1,0 +1,24 @@
+package com.alkemy.ong.service;
+
+import com.alkemy.ong.common.DtoUtils;
+import com.alkemy.ong.common.EntityUtils;
+import com.alkemy.ong.model.entity.Activity;
+import com.alkemy.ong.model.request.ActivityDetailsRequest;
+import com.alkemy.ong.model.response.ActivityDetailsResponse;
+import com.alkemy.ong.repository.IActivityRepository;
+import com.alkemy.ong.service.abstraction.ICreateActivityService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ActivityServiceImpl implements ICreateActivityService {
+
+  @Autowired
+  IActivityRepository activityRepository;
+
+  @Override
+  public ActivityDetailsResponse create(ActivityDetailsRequest activityRequest) {
+    Activity activity = DtoUtils.convertTo(activityRequest);
+    return EntityUtils.convertTo(activityRepository.save(activity));
+  }
+}

--- a/src/main/java/com/alkemy/ong/service/abstraction/ICreateActivityService.java
+++ b/src/main/java/com/alkemy/ong/service/abstraction/ICreateActivityService.java
@@ -1,0 +1,10 @@
+package com.alkemy.ong.service.abstraction;
+
+import com.alkemy.ong.model.request.ActivityDetailsRequest;
+import com.alkemy.ong.model.response.ActivityDetailsResponse;
+
+public interface ICreateActivityService {
+
+  ActivityDetailsResponse create(ActivityDetailsRequest activityRequest);
+
+}


### PR DESCRIPTION
The endpoint /activities was implemented with its corresponding validations, however a validation for the image was also added. While this was not requested by the ticket it was added because the Activity entity has the filed "image" set as nullable = false, whcih gives an error if said field is not present at the time the record is being saved on the database.

Evidence:
![Evidence1](https://user-images.githubusercontent.com/94468975/147629404-2cc4bea6-7399-4560-8b23-8a0486bf19e9.png)
![Evidence2](https://user-images.githubusercontent.com/94468975/147629402-0b11bce8-c588-41b4-a196-58e4354c5b11.png)


